### PR TITLE
Change install location of launcher to /Library/LaunchDaemons

### DIFF
--- a/IPTSDaemon/install_daemon.sh
+++ b/IPTSDaemon/install_daemon.sh
@@ -2,16 +2,16 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # remove old IPTSDaemon
-## removed launch script from both locations
+## unload IPTSDaemon from both locations
 launchctl unload /Library/LaunchAgents/com.xavier.IPTSDaemon.plist 2>/dev/null
 launchctl unload /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist 2>/dev/null
-## remove the remaining files
+## remove the files
 sudo rm /usr/local/bin/IPTSDaemon 2>/dev/null
 sudo rm /Library/LaunchAgents/com.xavier.IPTSDaemon.plist 2>/dev/null
 sudo rm /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist 2>/dev/null
 sudo rm -rf /usr/local/ipts_config 2>/dev/null
 
-# install IPTSDaemon and set permissions
+# install new/updated IPTSDaemon and set permissions
 sudo mkdir -p /usr/local/bin/
 sudo chmod -R 755 /usr/local/bin/
 sudo cp $DIR/IPTSDaemon /usr/local/bin/

--- a/IPTSDaemon/install_daemon.sh
+++ b/IPTSDaemon/install_daemon.sh
@@ -2,11 +2,16 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # remove old IPTSDaemon
+## removed launch script from both locations
 launchctl unload /Library/LaunchAgents/com.xavier.IPTSDaemon.plist 2>/dev/null
+launchctl unload /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist 2>/dev/null
+## remove the remaining files
 sudo rm /usr/local/bin/IPTSDaemon 2>/dev/null
 sudo rm /Library/LaunchAgents/com.xavier.IPTSDaemon.plist 2>/dev/null
+sudo rm /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist 2>/dev/null
 sudo rm -rf /usr/local/ipts_config 2>/dev/null
 
+# install IPTSDaemon and set permissions
 sudo mkdir -p /usr/local/bin/
 sudo chmod -R 755 /usr/local/bin/
 sudo cp $DIR/IPTSDaemon /usr/local/bin/
@@ -14,11 +19,13 @@ sudo chmod 755 /usr/local/bin/IPTSDaemon
 sudo chown root:wheel /usr/local/bin/IPTSDaemon
 sudo xattr -d com.apple.quarantine /usr/local/bin/IPTSDaemon 2>/dev/null
 
+# install config files for devices
 sudo cp -r $DIR/ipts_config /usr/local/
 
-sudo cp $DIR/com.xavier.IPTSDaemon.plist /Library/LaunchAgents
-sudo chmod 644 /Library/LaunchAgents/com.xavier.IPTSDaemon.plist
-sudo chown root:wheel /Library/LaunchAgents/com.xavier.IPTSDaemon.plist
-sudo xattr -d com.apple.quarantine /Library/LaunchAgents/com.xavier.IPTSDaemon.plist 2>/dev/null
+# install launcher for IPTSDaemon at boot
+sudo cp $DIR/com.xavier.IPTSDaemon.plist /Library/LaunchDaemons
+sudo chmod 644 /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist
+sudo chown root:wheel /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist
+sudo xattr -d com.apple.quarantine /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist 2>/dev/null
 
-launchctl load /Library/LaunchAgents/com.xavier.IPTSDaemon.plist
+launchctl load /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # IPTSDaemon
+
 This is the user space IPTS daemon for Surface touch screen process
 
 It is supposed to be used with `BigSurface.kext` to enable touch screen & stylus support on macOS.
@@ -15,21 +16,26 @@ To install the daemon, simply run the script `install_daemon.sh` and all files n
 
 You will also need to install two `dylib`(`fmt` and `inih`) and a daemon(`sleepwatcher`) for it to run properly.
 
-`Homebrew` is recommended to install them: in `Terminal`, execute `brew install fmt inih sleepwatcher`
+`Homebrew` is recommended to install them:
 
-Then, in order to **resume the service after wakeup**, you need to configure `sleepwatcher`: 
+1. Install [Homebrew](https://brew.sh)
+
+2. in `Terminal`, execute `brew install fmt inih sleepwatcher`
+
+Then, in order to **resume the service after wakeup**, you need to configure `sleepwatcher`:
 
 1. Create ~/.sleep and ~/.wakeup files.
-2. In .sleep: `launchctl unload /Library/LaunchAgents/com.xavier.IPTSDaemon.plist 2>/dev/null`
-3. In .wakeup: `sleep 2 && launchctl load /Library/LaunchAgents/com.xavier.IPTSDaemon.plist`
+2. In .sleep: `launchctl unload /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist 2>/dev/null`
+3. In .wakeup: `sleep 2 && launchctl load /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist`
 
 For example, you can:
+
 ```
 cd ~
 touch .sleep
 touch .wakeup
-echo "launchctl unload /Library/LaunchAgents/com.xavier.IPTSDaemon.plist 2>/dev/null" >> .sleep
-echo "sleep 2 && launchctl load /Library/LaunchAgents/com.xavier.IPTSDaemon.plist" >> .wakeup
+echo "launchctl unload /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist 2>/dev/null" >> .sleep
+echo "sleep 2 && launchctl load /Library/LaunchDaemons/com.xavier.IPTSDaemon.plist" >> .wakeup
 ```
 
 If you want to disable touch when palm is detected or stylus is detected or near the stylus, go to config folder and find your device's config, add this:
@@ -44,3 +50,7 @@ DisableTouch = true
 # disable touch near the stylus
 Cone = true
 ```
+
+### Enable on screen keyboard on login screen
+
+To enable the on screen keyboard to show up on the login screen you need to change your Accessibility settings in the `System Preferences>Users & Groups>Login Options>Accessibility Options` put a checkbox on the `Accessibility Keyboard`.


### PR DESCRIPTION
I updated the install script and the README to reflect the move of the launcher to `/Library/LaunchDaemons/`

This will enable the touch interface on the login screen when booting.